### PR TITLE
chore(dialyzer): remove the old behavior specification

### DIFF
--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -51,21 +51,8 @@
 %% Callback
 %%--------------------------------------------------------------------
 
--ifdef(use_specs).
-
 -callback(connect(ConnOpts :: list())
           -> {ok, pid()} | {error, Reason :: term()}).
-
--else.
-
--export([behaviour_info/1]).
-
-behaviour_info(callbacks) ->
-    [{connect, 1}];
-behaviour_info(_Other) ->
-    undefined.
-
--endif.
 
 %%--------------------------------------------------------------------
 %% API


### PR DESCRIPTION
This change is to avoid dialyzer checking errors in a module that implements `ecpool_worker` behavior.