### PR TITLE
chore(appup): fix typos

### DIFF
--- a/src/ecpool.appup.src
+++ b/src/ecpool.appup.src
@@ -1,4 +1,4 @@
-{<<"0\.5\..+">>,
+{VSN,
   [
     {"0.4.2", [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},


### PR DESCRIPTION
The version number of the target does not support regular expressions. When we compile the update package, it reports the following warning:
```
===> Warnings generating relup
          *WARNING* [{bad_vsn,{<<"0.5..+">>,"0.5.1"}},{bad_vsn,{<<"0.5..+">>,"0.5.1"}}]
```

We can use the `VSN` variable to bind it to the current version. see: https://github.com/emqx/relup_helper/commit/8a76b7c9d778e8df90bc83109944e0fcfed22110