### PR TITLE
fix(worker): kill children when removing the pool

### DIFF
--- a/src/ecpool.appup.src
+++ b/src/ecpool.appup.src
@@ -1,21 +1,31 @@
 %% -*-: erlang -*-
-{"0.5.1",
+{"0.5.2",
   [
-    {"0.4.2", [
-      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
-      {load_module, ecpool, brutal_purge, soft_purge, []}
+    {"0.5.1", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []}
     ]},
     {"0.5.0", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool_pool, brutal_purge, soft_purge, []}
+    ]},
+    {"0.4.2", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool_pool, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []}
     ]}
   ],
   [
-    {"0.4.2", [
-      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
-      {load_module, ecpool, brutal_purge, soft_purge, [ecpool_worker]}
+    {"0.5.1", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []}
     ]},
     {"0.5.0", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool_pool, brutal_purge, soft_purge, []}
+    ]},
+    {"0.4.2", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool_pool, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []}
     ]}
   ]
 }.


### PR DESCRIPTION
If a child hangs, it has no chance to shutdown because the 'EXIT' message will never be handled.