### PR TITLE
fix(ecpool_sup): stop pool {badmatch,{error,not_found}}

### DIFF
--- a/src/ecpool.appup.src
+++ b/src/ecpool.appup.src
@@ -2,30 +2,36 @@
 {"0.5.2",
   [
     {"0.5.1", [
-      {load_module, ecpool_worker, brutal_purge, soft_purge, []}
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
     ]},
     {"0.5.0", [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
-      {load_module, ecpool_pool, brutal_purge, soft_purge, []}
+      {load_module, ecpool_pool, brutal_purge, soft_purge, []},
+      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
     ]},
     {"0.4.2", [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool_pool, brutal_purge, soft_purge, []},
-      {load_module, ecpool, brutal_purge, soft_purge, []}
+      {load_module, ecpool, brutal_purge, soft_purge, []},
+      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
     ]}
   ],
   [
     {"0.5.1", [
-      {load_module, ecpool_worker, brutal_purge, soft_purge, []}
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
     ]},
     {"0.5.0", [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
-      {load_module, ecpool_pool, brutal_purge, soft_purge, []}
+      {load_module, ecpool_pool, brutal_purge, soft_purge, []},
+      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
     ]},
     {"0.4.2", [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool_pool, brutal_purge, soft_purge, []},
-      {load_module, ecpool, brutal_purge, soft_purge, []}
+      {load_module, ecpool, brutal_purge, soft_purge, []},
+      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
     ]}
   ]
 }.

--- a/src/ecpool_sup.erl
+++ b/src/ecpool_sup.erl
@@ -51,7 +51,7 @@ stop_pool(Pool) when is_atom(Pool) ->
     ChildId = child_id(Pool),
 	case supervisor:terminate_child(?MODULE, ChildId) of
         ok ->
-            ok = supervisor:delete_child(?MODULE, ChildId);
+            supervisor:delete_child(?MODULE, ChildId);
         {error, Reason} ->
             {error, Reason}
 	end.


### PR DESCRIPTION
```
2021-11-25T13:38:44.272963+08:00 [error] cluster_call error found, ResL: [{{{destroy_module_failure,'emqx@127.0.0.1'},{{emqx_module_subscriber_mqtt,on_module_destroy},{badmatch,{error,not_found}}}},[{ecpool_sup,stop_pool,1,[{file,"ecpool_sup.erl"},{line,54}]},{emqx_rule_actions_utils,stop_pool,1,[{file,"emqx_rule_actions_utils.erl"},{line,128}]},{emqx_modules,'-destroy_module/3-fun-0-',4,[{file,"emqx_modules.erl"},{line,281}]},{emqx_modules,destroy_module,3,[{file,"emqx_modules.erl"},{line,281}]},{erpc,execute_call,4,[{file,"erpc.erl"},{line,416}]}]}]
```