### PR TITLE
refactor: remove is_atom guards for pool names

### DIFF
--- a/include/ecpool.hrl
+++ b/include/ecpool.hrl
@@ -6,7 +6,6 @@
     | {handover_async, callback()}
     | no_handover.
 -type pool_type() :: random | hash | direct | round_robin.
--type pool_name() :: term().
 -type conn_callback() :: {module(), atom(), [any()]}.
 -type option() :: {pool_size, pos_integer()}
     | {pool_type, pool_type()}

--- a/src/ecpool.appup.src
+++ b/src/ecpool.appup.src
@@ -1,36 +1,32 @@
 %% -*-: erlang -*-
-{"0.5.2",
+{"0.5.3",
   [
-    {"0.5.1", [
+    {<<"0\\.5\\.[0-2]">>, [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
-      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
-    ]},
-    {"0.5.0", [
-      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
-      {load_module, ecpool_pool, brutal_purge, soft_purge, []},
-      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
+      {load_module, ecpool_sup, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []},
+      {load_module, ecpool_worker_sup, brutal_purge, soft_purge, []}
     ]},
     {"0.4.2", [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool_pool, brutal_purge, soft_purge, []},
       {load_module, ecpool, brutal_purge, soft_purge, []},
+      {load_module, ecpool_worker_sup, brutal_purge, soft_purge, []},
       {load_module, ecpool_sup, brutal_purge, soft_purge, []}
     ]}
   ],
   [
-    {"0.5.1", [
+    {<<"0\\.5\\.[0-2]">>, [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
-      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
-    ]},
-    {"0.5.0", [
-      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
-      {load_module, ecpool_pool, brutal_purge, soft_purge, []},
-      {load_module, ecpool_sup, brutal_purge, soft_purge, []}
+      {load_module, ecpool_sup, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []},
+      {load_module, ecpool_worker_sup, brutal_purge, soft_purge, []}
     ]},
     {"0.4.2", [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool_pool, brutal_purge, soft_purge, []},
       {load_module, ecpool, brutal_purge, soft_purge, []},
+      {load_module, ecpool_worker_sup, brutal_purge, soft_purge, []},
       {load_module, ecpool_sup, brutal_purge, soft_purge, []}
     ]}
   ]

--- a/src/ecpool_sup.erl
+++ b/src/ecpool_sup.erl
@@ -31,6 +31,8 @@
 %% Supervisor callbacks
 -export([init/1]).
 
+-type pool_name() :: ecpool:pool_name().
+
 %% @doc Start supervisor.
 -spec(start_link() -> {ok, pid()} | {error, term()}).
 start_link() ->
@@ -41,13 +43,13 @@ start_link() ->
 %%--------------------------------------------------------------------
 
 %% @doc Start a pool.
--spec(start_pool(atom(), atom(), list(tuple())) -> {ok, pid()} | {error, term()}).
-start_pool(Pool, Mod, Opts) when is_atom(Pool) ->
+-spec(start_pool(pool_name(), atom(), list(tuple())) -> {ok, pid()} | {error, term()}).
+start_pool(Pool, Mod, Opts) ->
     supervisor:start_child(?MODULE, pool_spec(Pool, Mod, Opts)).
 
 %% @doc Stop a pool.
--spec(stop_pool(Pool :: atom()) -> ok | {error, term()}).
-stop_pool(Pool) when is_atom(Pool) ->
+-spec(stop_pool(Pool :: pool_name()) -> ok | {error, term()}).
+stop_pool(Pool) ->
     ChildId = child_id(Pool),
 	case supervisor:terminate_child(?MODULE, ChildId) of
         ok ->
@@ -57,8 +59,8 @@ stop_pool(Pool) when is_atom(Pool) ->
 	end.
 
 %% @doc Get a pool.
--spec(get_pool(atom()) -> undefined | pid()).
-get_pool(Pool) when is_atom(Pool) ->
+-spec(get_pool(pool_name()) -> undefined | pid()).
+get_pool(Pool) ->
     ChildId = child_id(Pool),
     case [Pid || {Id, Pid, supervisor, _} <- supervisor:which_children(?MODULE), Id =:= ChildId] of
         [] -> undefined;
@@ -66,7 +68,7 @@ get_pool(Pool) when is_atom(Pool) ->
     end.
 
 %% @doc Get All Pools supervisored by the ecpool_sup.
--spec(pools() -> [{atom(), pid()}]).
+-spec(pools() -> [{pool_name(), pid()}]).
 pools() ->
     [{Pool, Pid} || {{pool_sup, Pool}, Pid, supervisor, _}
                     <- supervisor:which_children(?MODULE)].

--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -43,8 +43,10 @@
         , code_change/3
         ]).
 
+-type pool_name() :: ecpool:pool_name().
+
 -record(state, {
-          pool :: ecpool:pool_name(),
+          pool :: pool_name(),
           id :: pos_integer(),
           client :: pid() | undefined,
           mod :: module(),
@@ -66,7 +68,7 @@
 %%--------------------------------------------------------------------
 
 %% @doc Start a pool worker.
--spec(start_link(atom(), pos_integer(), module(), list()) ->
+-spec(start_link(pool_name(), pos_integer(), module(), list()) ->
       {ok, pid()} | ignore | {error, any()}).
 start_link(Pool, Id, Mod, Opts) ->
     gen_server:start_link(?MODULE, [Pool, Id, Mod, Opts], []).

--- a/src/ecpool_worker_sup.erl
+++ b/src/ecpool_worker_sup.erl
@@ -22,7 +22,7 @@
 
 -export([init/1]).
 
-start_link(Pool, Mod, Opts) when is_atom(Pool) ->
+start_link(Pool, Mod, Opts) ->
     supervisor:start_link(?MODULE, [Pool, Mod, Opts]).
 
 init([Pool, Mod, Opts]) ->

--- a/test/ecpool_SUITE.erl
+++ b/test/ecpool_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--define(POOL, test_pool).
+-define(POOL, <<"test_pool">>).
 
 -define(POOL_OPTS,
         [%% schedulers number
@@ -68,8 +68,8 @@ end_per_suite(_Config) ->
 
 t_start_pool(_Config) ->
     ecpool:start_pool(?POOL, test_client, ?POOL_OPTS),
-    ?assertEqual(10, length(ecpool:workers(test_pool))),
-    ?debugFmt("~p~n",  [ecpool:workers(test_pool)]),
+    ?assertEqual(10, length(ecpool:workers(?POOL))),
+    ?debugFmt("~p~n",  [ecpool:workers(?POOL)]),
     lists:foreach(fun(I) ->
                       ecpool:with_client(?POOL, fun(Client) ->
                                                         ?debugFmt("Call ~p: ~p~n", [I, Client])


### PR DESCRIPTION
`gproc_pool` accepts `any()` as pool name.
https://github.com/uwiger/gproc/blob/0.8.0/src/gproc_pool.erl#L102-L104

the forced `is_atom` guards impose atom leaks for dynamic pools.