### PR TITLE
fix: avoid stopping already dead clients

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp_release: 21
           - otp_release: 22
           - otp_release: 23
           - otp_release: 24
+          - otp_release: 25
 
     steps:
     - uses: actions/checkout@v2

--- a/src/ecpool.appup.src
+++ b/src/ecpool.appup.src
@@ -1,6 +1,10 @@
 %% -*-: erlang -*-
-{"0.5.3",
+{"0.5.4",
   [
+    {"0.5.3", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []}
+    ]},
     {<<"0\\.5\\.[0-2]">>, [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool_sup, brutal_purge, soft_purge, []},
@@ -16,6 +20,10 @@
     ]}
   ],
   [
+    {"0.5.3", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []}
+    ]},
     {<<"0\\.5\\.[0-2]">>, [
       {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool_sup, brutal_purge, soft_purge, []},

--- a/test/test_failing_client.erl
+++ b/test/test_failing_client.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,4 +21,4 @@
 -export([connect/1]).
 
 connect(_Options) ->
-    {error, unreachable}.
+    {ok, erlang:spawn_link(fun() -> ok end)}.


### PR DESCRIPTION
And stop littering the log with confusing messages, for example:
```
[PoolWorker] supervisee <0.292.0> terminated with error: noproc
```

Also unbreak the testcase introduced in #34.