### PR TITLE
fix: avoid crash report when initial connect fails

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -15,10 +15,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp_release: 22
-          - otp_release: 23
           - otp_release: 24
           - otp_release: 25
+          - otp_release: 26
 
     steps:
     - uses: actions/checkout@v2

--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,8 @@
 
 {profiles, [
     {test, [
-        {deps, [{meck, {git, "https://github.com/eproxus/meck.git", {ref, "dfb47c544bdf14b5c26ff2651cf9339dbbe2f50e"}}},
-                {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.0"}}}]}
+        {deps, [{meck, "0.9.2"},
+                {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.0"}}}]},
+        {erl_opts, [debug_info]}
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -31,3 +31,10 @@
     {plt_apps, all_deps}
    ]
 }.
+
+{profiles, [
+    {test, [
+        {deps, [{meck, {git, "https://github.com/eproxus/meck.git", {ref, "dfb47c544bdf14b5c26ff2651cf9339dbbe2f50e"}}},
+                {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.0"}}}]}
+    ]}
+]}.

--- a/src/ecpool.erl
+++ b/src/ecpool.erl
@@ -88,7 +88,8 @@ start_pool(Pool, Mod, Opts) ->
         ok ->
            OkResponse ;
         Error ->
-            exit(Pid, normal),
+            unlink(Pid),
+            exit(Pid, shutdown),
             Error
     end.
 

--- a/src/ecpool_pool_sup.erl
+++ b/src/ecpool_pool_sup.erl
@@ -24,13 +24,18 @@
 %% Supervisor callbacks
 -export([init/1]).
 
-start_link(Pool, Mod, Opts, InitialConnectResultReceiver) ->
-    supervisor:start_link(?MODULE, [Pool, Mod, Opts, InitialConnectResultReceiver]).
+start_link(Pool, Mod, Opts, InitialConnectResultReceiverAlias) ->
+    supervisor:start_link(?MODULE, [Pool, Mod, Opts, InitialConnectResultReceiverAlias]).
 
-init([Pool, Mod, Opts, InitialConnectResultReceiver]) ->
+init([Pool, Mod, Opts, InitialConnectResultReceiverAlias]) ->
     {ok, { {one_for_all, 10, 100}, [
             {pool, {ecpool_pool, start_link, [Pool, Opts]},
                 transient, 16#ffff, worker, [ecpool_pool]},
-            {worker_sup, {ecpool_worker_sup, start_link, [Pool, Mod, Opts, InitialConnectResultReceiver]},
-                transient, infinity, supervisor, [ecpool_worker_sup]}] }}.
+            {worker_sup,
+             {ecpool_worker_sup,start_link,
+              [Pool, Mod, Opts, InitialConnectResultReceiverAlias]},
+             transient,
+             infinity,
+             supervisor,
+             [ecpool_worker_sup]}] }}.
 

--- a/src/ecpool_pool_sup.erl
+++ b/src/ecpool_pool_sup.erl
@@ -19,18 +19,18 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/3]).
+-export([start_link/4]).
 
 %% Supervisor callbacks
 -export([init/1]).
 
-start_link(Pool, Mod, Opts) ->
-    supervisor:start_link(?MODULE, [Pool, Mod, Opts]).
+start_link(Pool, Mod, Opts, InitialConnectResultReceiver) ->
+    supervisor:start_link(?MODULE, [Pool, Mod, Opts, InitialConnectResultReceiver]).
 
-init([Pool, Mod, Opts]) ->
+init([Pool, Mod, Opts, InitialConnectResultReceiver]) ->
     {ok, { {one_for_all, 10, 100}, [
             {pool, {ecpool_pool, start_link, [Pool, Opts]},
                 transient, 16#ffff, worker, [ecpool_pool]},
-            {worker_sup, {ecpool_worker_sup, start_link, [Pool, Mod, Opts]},
+            {worker_sup, {ecpool_worker_sup, start_link, [Pool, Mod, Opts, InitialConnectResultReceiver]},
                 transient, infinity, supervisor, [ecpool_worker_sup]}] }}.
 

--- a/src/ecpool_sup.erl
+++ b/src/ecpool_sup.erl
@@ -21,7 +21,7 @@
 -export([start_link/0]).
 
 %% API
--export([ start_pool/3
+-export([ start_pool/4
         , stop_pool/1
         , get_pool/1
         ]).
@@ -43,9 +43,9 @@ start_link() ->
 %%--------------------------------------------------------------------
 
 %% @doc Start a pool.
--spec(start_pool(pool_name(), atom(), list(tuple())) -> {ok, pid()} | {error, term()}).
-start_pool(Pool, Mod, Opts) ->
-    supervisor:start_child(?MODULE, pool_spec(Pool, Mod, Opts)).
+-spec(start_pool(pool_name(), atom(), list(tuple()), {pid(), reference()}) -> {ok, pid()} | {error, term()}).
+start_pool(Pool, Mod, Opts, InitialConnectResultReceiver) ->
+    supervisor:start_child(?MODULE, pool_spec(Pool, Mod, Opts, InitialConnectResultReceiver)).
 
 %% @doc Stop a pool.
 -spec(stop_pool(Pool :: pool_name()) -> ok | {error, term()}).
@@ -80,9 +80,9 @@ pools() ->
 init([]) ->
     {ok, {{one_for_one, 10, 100}, [ecpool_monitor:monitor_spec()]}}.
 
-pool_spec(Pool, Mod, Opts) ->
+pool_spec(Pool, Mod, Opts, InitialConnectResultReceiver) ->
     #{id => child_id(Pool),
-      start => {ecpool_pool_sup, start_link, [Pool, Mod, Opts]},
+      start => {ecpool_pool_sup, start_link, [Pool, Mod, Opts, InitialConnectResultReceiver]},
       restart => transient,
       shutdown => infinity,
       type => supervisor,

--- a/src/ecpool_sup.erl
+++ b/src/ecpool_sup.erl
@@ -43,9 +43,10 @@ start_link() ->
 %%--------------------------------------------------------------------
 
 %% @doc Start a pool.
--spec(start_pool(pool_name(), atom(), list(tuple()), {pid(), reference()}) -> {ok, pid()} | {error, term()}).
-start_pool(Pool, Mod, Opts, InitialConnectResultReceiver) ->
-    supervisor:start_child(?MODULE, pool_spec(Pool, Mod, Opts, InitialConnectResultReceiver)).
+-spec(start_pool(pool_name(), atom(), list(tuple()), reference()) -> {ok, pid()} | {error, term()}).
+start_pool(Pool, Mod, Opts, InitialConnectResultReceiverAlias) ->
+    supervisor:start_child(?MODULE,
+                           pool_spec(Pool, Mod, Opts, InitialConnectResultReceiverAlias)).
 
 %% @doc Stop a pool.
 -spec(stop_pool(Pool :: pool_name()) -> ok | {error, term()}).
@@ -80,9 +81,11 @@ pools() ->
 init([]) ->
     {ok, {{one_for_one, 10, 100}, [ecpool_monitor:monitor_spec()]}}.
 
-pool_spec(Pool, Mod, Opts, InitialConnectResultReceiver) ->
+pool_spec(Pool, Mod, Opts, InitialConnectResultReceiverAlias) ->
     #{id => child_id(Pool),
-      start => {ecpool_pool_sup, start_link, [Pool, Mod, Opts, InitialConnectResultReceiver]},
+      start => {ecpool_pool_sup,
+                start_link,
+                [Pool, Mod, Opts, InitialConnectResultReceiverAlias]},
       restart => transient,
       shutdown => infinity,
       type => supervisor,

--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -137,7 +137,7 @@ init([Pool, Id, Mod, Opts, InitialConnectResultReceiver]) ->
             {ok, NewState};
         Error -> 
             send_initial_connect_response(InitialConnectResultReceiver, Error),
-            {ok, State}
+            ignore
     end.
 
 handle_call(is_connected, _From, State = #state{client = Client}) when is_pid(Client) ->

--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -69,9 +69,9 @@
 %% @doc Start a pool worker.
 -spec(start_link(pool_name(), pos_integer(), module(), list(), {pid(), reference()}) ->
       {ok, pid()} | ignore | {error, any()}).
-start_link(Pool, Id, Mod, Opts, InitialConnectResultReceiver) ->
+start_link(Pool, Id, Mod, Opts, InitialConnectResultReceiverAlias) ->
     gen_server:start_link(?MODULE,
-                          [Pool, Id, Mod, Opts, InitialConnectResultReceiver],
+                          [Pool, Id, Mod, Opts, InitialConnectResultReceiverAlias],
                           []).
 
 %% @doc Get client/connection.
@@ -120,7 +120,7 @@ add_disconnect_callback(Pid, OnDisconnect) ->
 %% gen_server callbacks
 %%--------------------------------------------------------------------
 
-init([Pool, Id, Mod, Opts, InitialConnectResultReceiver]) ->
+init([Pool, Id, Mod, Opts, InitialConnectResultReceiverAlias]) ->
     ecpool_monitor:reg_worker(),
     process_flag(trap_exit, true),
     State = #state{pool = Pool,
@@ -133,10 +133,10 @@ init([Pool, Id, Mod, Opts, InitialConnectResultReceiver]) ->
     case connect_internal(State) of
         {ok, NewState} ->
             gproc_pool:connect_worker(ecpool:name(Pool), {Pool, Id}),
-            send_initial_connect_response(InitialConnectResultReceiver, ok),
+            send_initial_connect_response(InitialConnectResultReceiverAlias, ok),
             {ok, NewState};
         Error -> 
-            send_initial_connect_response(InitialConnectResultReceiver, Error),
+            send_initial_connect_response(InitialConnectResultReceiverAlias, Error),
             ignore
     end.
 
@@ -380,6 +380,6 @@ monitor_child(Pid) ->
             ok
     end.
 
-send_initial_connect_response({InitialConnectResultReceiverPid, Ref}, Response) ->
-    InitialConnectResultReceiverPid ! {Ref, Response},
+send_initial_connect_response(InitialConnectResultReceiverAlias, Response) ->
+    InitialConnectResultReceiverAlias ! {InitialConnectResultReceiverAlias, Response},
     ok.

--- a/src/ecpool_worker_sup.erl
+++ b/src/ecpool_worker_sup.erl
@@ -24,15 +24,15 @@
 
 -export([pool_size/1]).
 
-start_link(Pool, Mod, Opts, InitialConnectResultReceiver) ->
-    supervisor:start_link(?MODULE, [Pool, Mod, Opts, InitialConnectResultReceiver]).
+start_link(Pool, Mod, Opts, InitialConnectResultReceiverAlias) ->
+    supervisor:start_link(?MODULE, [Pool, Mod, Opts, InitialConnectResultReceiverAlias]).
 
-init([Pool, Mod, Opts, InitialConnectResultReceiver]) ->
+init([Pool, Mod, Opts, InitialConnectResultReceiverAlias]) ->
     WorkerSpec = fun(Id) ->
                      #{id => {worker, Id},
                        start => {ecpool_worker,
                                  start_link,
-                                 [Pool, Id, Mod, Opts, InitialConnectResultReceiver]},
+                                 [Pool, Id, Mod, Opts, InitialConnectResultReceiverAlias]},
                        restart => transient,
                        shutdown => 5000,
                        type => worker,

--- a/src/ecpool_worker_sup.erl
+++ b/src/ecpool_worker_sup.erl
@@ -18,17 +18,21 @@
 
 -behaviour(supervisor).
 
--export([start_link/3]).
+-export([start_link/4]).
 
 -export([init/1]).
 
-start_link(Pool, Mod, Opts) ->
-    supervisor:start_link(?MODULE, [Pool, Mod, Opts]).
+-export([pool_size/1]).
 
-init([Pool, Mod, Opts]) ->
+start_link(Pool, Mod, Opts, InitialConnectResultReceiver) ->
+    supervisor:start_link(?MODULE, [Pool, Mod, Opts, InitialConnectResultReceiver]).
+
+init([Pool, Mod, Opts, InitialConnectResultReceiver]) ->
     WorkerSpec = fun(Id) ->
                      #{id => {worker, Id},
-                       start => {ecpool_worker, start_link, [Pool, Id, Mod, Opts]},
+                       start => {ecpool_worker,
+                                 start_link,
+                                 [Pool, Id, Mod, Opts, InitialConnectResultReceiver]},
                        restart => transient,
                        shutdown => 5000,
                        type => worker,

--- a/test/ecpool_SUITE.erl
+++ b/test/ecpool_SUITE.erl
@@ -96,7 +96,7 @@ t_start_pool_initial_connect_fail(_Config) ->
     ok.
 
 t_start_sup_pool_one_initial_connect_fail(_Config) ->
-    meck:new(test_client),
+    meck:new(test_client, [passthrough]),
     meck:expect(test_client,
                 connect,
                 fun(_Opts) ->
@@ -108,7 +108,7 @@ t_start_sup_pool_one_initial_connect_fail(_Config) ->
     ok.
 
 t_start_pool_one_initial_connect_fail(_Config) ->
-    meck:new(test_client),
+    meck:new(test_client, [passthrough]),
     meck:expect(test_client,
                 connect,
                 fun(_Opts) ->

--- a/test/test_client_connect_fail.erl
+++ b/test/test_client_connect_fail.erl
@@ -1,0 +1,24 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(test_client_connect_fail).
+
+-behaviour(ecpool_worker).
+
+-export([connect/1]).
+
+connect(_Options) ->
+    {error, <<"FAIL_REASON">>}.


### PR DESCRIPTION
Problem:

Previously, the initial connection attempt in pool workers was made in the gen_server init function. If this connection failed, the init function would return a stop tuple, resulting in crash report log entries for the gen_server and its supervisor (unless crash report logging was disabled).

Solution:

This commit prevents these confusing crash reports by moving the initial connection attempt out of the init function. Instead, the connection is now attempted in a gen_server call that occurs right after the worker starts. To maintain consistent error handling in ecpool:start_pool and ecpool:start_sup_pool, errors from the initial connection failure are passed as process messages.