### PR TITLE
0930 deduplicate reconnect callbacks

### DIFF
--- a/src/ecpool.appup.src
+++ b/src/ecpool.appup.src
@@ -1,7 +1,15 @@
 %% -*-: erlang -*-
-{"0.5.6",
+{"0.5.7.1",
   [
+    {"0.5.7", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []}
+    ]},
+    {"0.5.6", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []}
+    ]},
     {"0.5.5", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool, brutal_purge, soft_purge, []}
     ]},
     {"0.5.4", [
@@ -27,7 +35,15 @@
     ]}
   ],
   [
+    {"0.5.7", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []}
+    ]},
+    {"0.5.6", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []}
+    ]},
     {"0.5.5", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool, brutal_purge, soft_purge, []}
     ]},
     {"0.5.4", [

--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -297,11 +297,9 @@ ensure_callback(undefined) -> undefined;
 ensure_callback({_,_,_} = Callback) -> Callback.
 
 add_conn_callback(OnReconnect, OldOnReconnects) when is_list(OldOnReconnects) ->
-    [OnReconnect | OldOnReconnects];
+    OldOnReconnects ++ [OnReconnect];
 add_conn_callback(OnReconnect, undefined) ->
-    [OnReconnect];
-add_conn_callback(OnReconnect, OldOnReconnect) ->
-    [OnReconnect, OldOnReconnect].
+    [OnReconnect].
 
 remove_conn_callback({Mod, Fn}, Callbacks) ->
     lists:filter(fun({Mod0, Fn0, _Args}) -> {Mod0, Fn0} =/= {Mod, Fn} end, Callbacks).


### PR DESCRIPTION
fixes [EEC-1097](https://emqx.atlassian.net/browse/EEC-1097)

The issue, is the reconnect callbacks are evaluated in the reversed order when they were added.
But the infinite growth of the list is a ticking bomb.
So this PR also made an attempt to make it possible to deduplicate.

The fix is quite hacky in oder to support hot-upgrade.