### PR TITLE
0930 deduplicate reconnect callbacks 0.5.9

### DIFF
--- a/src/ecpool.appup.src
+++ b/src/ecpool.appup.src
@@ -1,7 +1,15 @@
 %% -*-: erlang -*-
-{"0.5.6",
+{"0.5.7.1",
   [
+    {"0.5.7", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []}
+    ]},
+    {"0.5.6", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []}
+    ]},
     {"0.5.5", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool, brutal_purge, soft_purge, []}
     ]},
     {"0.5.4", [
@@ -27,7 +35,15 @@
     ]}
   ],
   [
+    {"0.5.7", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []}
+    ]},
+    {"0.5.6", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
+      {load_module, ecpool, brutal_purge, soft_purge, []}
+    ]},
     {"0.5.5", [
+      {load_module, ecpool_worker, brutal_purge, soft_purge, []},
       {load_module, ecpool, brutal_purge, soft_purge, []}
     ]},
     {"0.5.4", [

--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -30,6 +30,8 @@
         , set_disconnect_callback/2
         , add_reconnect_callback/2
         , remove_reconnect_callback/2
+        , remove_reconnect_callback_by_signature/2
+        , get_reconnect_callbacks/1
         , add_disconnect_callback/2
         ]).
 
@@ -110,6 +112,14 @@ add_reconnect_callback(Pid, OnReconnect) ->
 remove_reconnect_callback(Pid, OnReconnect) ->
     gen_server:cast(Pid, {remove_reconn_callbk, OnReconnect}).
 
+-spec(remove_reconnect_callback_by_signature(pid(), term()) -> ok).
+remove_reconnect_callback_by_signature(Pid, CallbackSignature) ->
+    gen_server:cast(Pid, {remove_reconnect_callback_by_signature, CallbackSignature}).
+
+-spec(get_reconnect_callbacks(pid()) -> [{module(), atom(), list()}]).
+get_reconnect_callbacks(Pid) ->
+    gen_server:call(Pid, get_reconnect_callbacks, infinity).
+
 -spec(add_disconnect_callback(pid(), ecpool:conn_callback()) -> ok).
 add_disconnect_callback(Pid, OnDisconnect) ->
     gen_server:cast(Pid, {add_disconn_callbk, OnDisconnect}).
@@ -151,6 +161,9 @@ handle_call(client, _From, State = #state{client = Client}) ->
 handle_call({exec, Action}, _From, State = #state{client = Client}) ->
     {reply, safe_exec(Action, Client), State};
 
+handle_call(get_reconnect_callbacks, _From, #state{on_reconnect = OnReconnect} = State) ->
+    {reply, OnReconnect, State};
+
 handle_call(Req, _From, State) ->
     logger:error("[PoolWorker] unexpected call: ~p", [Req]),
     {reply, ignored, State}.
@@ -172,20 +185,16 @@ handle_cast({set_disconn_callbk, OnDisconnect}, State) ->
 handle_cast({add_reconn_callbk, OnReconnect}, State = #state{on_reconnect = OldOnReconnect0}) ->
     OldOnReconnect =
         case reconnect_callback_signature(OnReconnect) of
-            {ok, S1} ->
-                lists:filter(
-                    fun(CB) ->
-                            case reconnect_callback_signature(CB) of
-                                {ok, S2} when S1 =:= S2 ->
-                                    false;
-                                _ ->
-                                    true
-                            end
-                    end, OldOnReconnect0);
+            {ok, Signature} ->
+                drop_reconnect_callbacks_by_signature(OldOnReconnect0, Signature);
             error ->
                 OldOnReconnect0
         end,
     {noreply, State#state{on_reconnect = add_conn_callback(OnReconnect, OldOnReconnect)}};
+
+handle_cast({remove_reconnect_callback_by_signature, CallbackSignature}, State = #state{on_reconnect = OnReconnect0}) ->
+    OldOnReconnect = drop_reconnect_callbacks_by_signature(OnReconnect0, CallbackSignature),
+    {noreply, State#state{on_reconnect = OldOnReconnect}};
 
 handle_cast({remove_reconn_callbk, OnReconnect}, State = #state{on_reconnect = OldOnReconnect}) ->
     {noreply, State#state{on_reconnect = remove_conn_callback(OnReconnect, OldOnReconnect)}};
@@ -304,6 +313,18 @@ reconnect_callback_signature({M, _, A}) ->
     end;
 reconnect_callback_signature({M, _, A}) ->
     error.
+
+is_reconnct_calback_signature_match(CB, Sig) ->
+    case reconnect_callback_signature(CB) of
+        {ok, Sig2} ->
+            Sig2 =:= Sig;
+        _ ->
+            false
+    end.
+
+drop_reconnect_callbacks_by_signature(Callbacks, Signature) ->
+    Pred = fun(CB) -> not is_reconnct_calback_signature_match(CB, Signature) end,
+    lists:filter(Pred, Callbacks).
 
 safe_exec({_M, _F, _A} = Action, MainArg) ->
     try exec(Action, MainArg)

--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -310,11 +310,9 @@ reconnect_callback_signature({M, _, A}) ->
     catch
         _:_ ->
             error
-    end;
-reconnect_callback_signature({M, _, A}) ->
-    error.
+    end.
 
-is_reconnct_calback_signature_match(CB, Sig) ->
+is_reconnect_calback_signature_match(CB, Sig) ->
     case reconnect_callback_signature(CB) of
         {ok, Sig2} ->
             Sig2 =:= Sig;
@@ -323,7 +321,7 @@ is_reconnct_calback_signature_match(CB, Sig) ->
     end.
 
 drop_reconnect_callbacks_by_signature(Callbacks, Signature) ->
-    Pred = fun(CB) -> not is_reconnct_calback_signature_match(CB, Signature) end,
+    Pred = fun(CB) -> not is_reconnect_calback_signature_match(CB, Signature) end,
     lists:filter(Pred, Callbacks).
 
 safe_exec({_M, _F, _A} = Action, MainArg) ->

--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -278,8 +278,9 @@ reconnect(Secs, State = #state{client = Client, on_disconnect = Disconnect, supe
 handle_reconnect(undefined, _) ->
     ok;
 handle_reconnect(Client, OnReconnectList) when is_list(OnReconnectList) ->
+    %% reverse apply the callbacks because the newer ones are cons-ed to the head of the list
     lists:foreach(fun(OnReconnectCallback) -> safe_exec(OnReconnectCallback, Client) end,
-                  OnReconnectList).
+                  lists:reverse(OnReconnectList)).
 
 handle_disconnect(undefined, _) ->
     ok;
@@ -347,7 +348,7 @@ ensure_callback(Callbacks) when is_list(Callbacks) ->
     lists:map(fun({_, _, _} = Callback) -> Callback end, Callbacks).
 
 add_conn_callback(OnReconnect, OldOnReconnects) when is_list(OldOnReconnects) ->
-    OldOnReconnects ++ [OnReconnect].
+    [OnReconnect | OldOnReconnects].
 
 remove_conn_callback({Mod, Fn}, Callbacks) when is_list(Callbacks) ->
     lists:filter(fun({Mod0, Fn0, _Args}) -> {Mod0, Fn0} =/= {Mod, Fn} end, Callbacks).

--- a/src/ecpool_worker.erl
+++ b/src/ecpool_worker.erl
@@ -297,11 +297,9 @@ ensure_callback(undefined) -> undefined;
 ensure_callback({_,_,_} = Callback) -> Callback.
 
 add_conn_callback(OnReconnect, OldOnReconnects) when is_list(OldOnReconnects) ->
-    [OnReconnect | OldOnReconnects];
+    OldOnReconnects ++ [OnReconnect];
 add_conn_callback(OnReconnect, undefined) ->
-    [OnReconnect];
-add_conn_callback(OnReconnect, OldOnReconnect) ->
-    [OnReconnect, OldOnReconnect].
+    [OnReconnect].
 
 remove_conn_callback({Mod, Fn}, Callbacks) ->
     lists:filter(fun({Mod0, Fn0, _Args}) -> {Mod0, Fn0} =/= {Mod, Fn} end, Callbacks).


### PR DESCRIPTION
fixes [EEC-1097](https://emqx.atlassian.net/browse/EEC-1097)

The issue, is the reconnect callbacks are evaluated in the reversed order when they were added.
But the infinite growth of the list is a ticking bomb.
So this PR also made an attempt to make it possible to deduplicate.

The fix is quite hacky in oder to support hot-upgrade.

related: https://github.com/emqx/epgsql/pull/11